### PR TITLE
Handle new node content types

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,11 +141,13 @@ async function chatgptToMarkdown(json, sourceDir, { dateFormat } = { dateFormat:
     const fileName = `${sanitizedTitle}.md`;
     const filePath = path.join(sourceDir, fileName);
     const title = `# ${wrapHtmlTagsInBackticks(conversation.title)}\n`;
-    const metadata = [
+    const lines = [
       `- Created: ${dateFormat(new Date(conversation.create_time * 1000))}\n`,
       `- Updated: ${dateFormat(new Date(conversation.update_time * 1000))}\n`,
       `- Link: https://chatgpt.com/c/${conversation.conversation_id}\n`,
-    ].join("");
+    ];
+    if (conversation.gizmo_id) lines.push(`- Project: https://chatgpt.com/g/${conversation.gizmo_id}/project\n`);
+    const metadata = lines.join("");
     const messages = Object.values(conversation.mapping).map(nodeToMarkdown).join("");
     const markdownContent = `${title}\n${metadata}\n${messages}`;
     await fs.writeFile(filePath, markdownContent, "utf8");

--- a/index.js
+++ b/index.js
@@ -38,6 +38,74 @@ function indent(str) {
     .join("");
 }
 
+function blockquote(str) {
+  return str
+    .split("\n")
+    .map((v) => (v ? `> ${v}` : ">"))
+    .join("\n");
+}
+
+function nodeToMarkdown(node) {
+  try {
+    const content = node.message?.content;
+    if (!content) return "";
+    let body;
+    switch (content.content_type) {
+      case "text":
+        body = content.parts.join("\n");
+        break;
+      case "code":
+        body = "```" + content.language.replace("unknown", "") + "\n" + content.text + "\n```";
+        break;
+      case "execution_output":
+        body = "```\n" + content.text + "\n```";
+        break;
+      case "multimodal_text":
+        body = content.parts
+          .map((part) =>
+            typeof part == "string"
+              ? `${part}\n\n`
+              : part.content_type === "image_asset_pointer"
+                ? `Image (${part.width}x${part.height}): ${part?.metadata?.dalle?.prompt ?? ""}\n\n`
+                : `${part.content_type}\n\n`,
+          )
+          .join("");
+        break;
+      case "tether_browsing_display":
+        body = "```\n" + (content.summary ? `${content.summary}\n` : "") + content.result + "\n```";
+        break;
+      case "tether_quote":
+        body = blockquote(`${content.title} (${content.url})\n\n${content.text}`);
+        break;
+      case "system_error":
+        body = `${content.name}\n\n${content.text}\n\n`;
+        break;
+      case "user_editable_context":
+        body = "";
+        break;
+      case "thoughts":
+        body = content.thoughts.map((t) => `##### ${t.summary}\n\n${t.content}\n`).join("\n");
+        break;
+      case "reasoning_recap":
+        body = blockquote(content.content);
+        break;
+      case "sonic_webpage":
+        body = "```\n" + `${content.title} (${content.url})\n\n${content.text}` + "\n```";
+        break;
+      default:
+        body = String(content);
+    }
+    if (!body.trim()) return "";
+    const author = node.message.author;
+    if (author.role == "user") body = indent(body);
+    if (author.role == "tool" && !body.startsWith("```") && !body.endsWith("```")) body = indent(body);
+    return `## ${author.role}${author.name ? ` (${author.name})` : ""}\n\n${body}\n\n`;
+  } catch (err) {
+    err.message += `\nNode: ${JSON.stringify(node)}`;
+    throw err;
+  }
+}
+
 const dateFormat = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
   month: "short",
@@ -78,60 +146,7 @@ async function chatgptToMarkdown(json, sourceDir, { dateFormat } = { dateFormat:
       `- Updated: ${dateFormat(new Date(conversation.update_time * 1000))}\n`,
       `- Link: https://chatgpt.com/c/${conversation.conversation_id}\n`,
     ].join("");
-    const messages = Object.values(conversation.mapping)
-      .map((node) => {
-        let content = node.message?.content;
-        if (!content) return "";
-        // Format the body based on the content type
-        let body;
-        switch (content.content_type) {
-          case "text":
-            body = content.parts.join("\n");
-            break;
-          case "code":
-            body = "```" + content.language.replace("unknown", "") + "\n" + content.text + "\n```";
-            break;
-          case "execution_output":
-            body = "```\n" + content.text + "\n```";
-            break;
-          case "multimodal_text":
-            body = content.parts
-              .map((part) =>
-                typeof part == "string"
-                  ? `${part}\n\n`
-                  : part.content_type === "image_asset_pointer"
-                    ? `Image (${part.width}x${part.height}): ${part?.metadata?.dalle?.prompt ?? ""}\n\n`
-                    : `${part.content_type}\n\n`,
-              )
-              .join("");
-            break;
-          case "tether_browsing_display":
-            body = "```\n" + (content.summary ? `${content.summary}\n` : "") + content.result + "\n```";
-            break;
-          case "tether_quote":
-            body = "```\n" + `${content.title} (${content.url})\n\n${content.text}` + "\n```";
-            break;
-          case "system_error":
-            body = `${content.name}\n\n${content.text}\n\n`;
-            break;
-          case "user_editable_context":
-            // We don't want to pollute all Markdown with custom instuctions
-            // in content.user_instructions. So skip it
-            body = "";
-            break;
-          default:
-            body = content;
-            break;
-        }
-        // Ignore empty content
-        if (!body.trim()) return "";
-        // Indent user / tool messages. The sometimes contain code and whitespaces are relevant
-        const author = node.message.author;
-        if (author.role == "user") body = indent(body);
-        if (author.role == "tool" && !body.startsWith("```") && !body.endsWith("```")) body = indent(body);
-        return `## ${author.role}${author.name ? ` (${author.name})` : ""}\n\n${body}\n\n`;
-      })
-      .join("");
+    const messages = Object.values(conversation.mapping).map(nodeToMarkdown).join("");
     const markdownContent = `${title}\n${metadata}\n${messages}`;
     await fs.writeFile(filePath, markdownContent, "utf8");
     await fs.utimes(filePath, conversation.update_time, conversation.create_time);

--- a/index.test.js
+++ b/index.test.js
@@ -439,4 +439,20 @@ describe("chatgptToMarkdown", () => {
     expect(fileContent).toContain("Title (https://a.com)");
     expect(fileContent).toContain("Body");
   });
+
+  it("should include gizmo project link", async () => {
+    const json = [
+      {
+        title: "Test Conversation",
+        conversation_id: "abc",
+        create_time: 1630454400,
+        update_time: 1630458000,
+        gizmo_id: "g123",
+        mapping: {},
+      },
+    ];
+    await chatgptToMarkdown(json, tempDir);
+    const fileContent = await fs.readFile(path.join(tempDir, "Test Conversation.md"), "utf8");
+    expect(fileContent).toContain("- Project: https://chatgpt.com/g/g123/project");
+  });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -171,7 +171,7 @@ describe("chatgptToMarkdown", () => {
     ];
     await chatgptToMarkdown(json, tempDir);
     const fileContent = await fs.readFile(path.join(tempDir, "Test Conversation.md"), "utf8");
-    expect(fileContent).toContain("```\nT (x.com)\n\nX\n```");
+    expect(fileContent).toContain("    > T (x.com)\n    >\n    > X");
   });
 
   it("should handle multimodal_text content", async () => {
@@ -376,5 +376,67 @@ describe("chatgptToMarkdown", () => {
 
     await chatgptToMarkdown(json, tempDir);
     await expect(fs.access(path.join(tempDir, "abc123.md"))).resolves.not.toThrow();
+  });
+
+  it("should handle thoughts content", async () => {
+    const json = [
+      {
+        title: "Test Conversation",
+        create_time: 1630454400,
+        update_time: 1630458000,
+        mapping: {
+          0: {
+            message: {
+              author: { role: "assistant" },
+              content: { content_type: "thoughts", thoughts: [{ summary: "Sum", content: "Detail" }] },
+            },
+          },
+        },
+      },
+    ];
+    await chatgptToMarkdown(json, tempDir);
+    const fileContent = await fs.readFile(path.join(tempDir, "Test Conversation.md"), "utf8");
+    expect(fileContent).toContain("##### Sum");
+    expect(fileContent).toContain("Detail");
+  });
+
+  it("should handle reasoning_recap content", async () => {
+    const json = [
+      {
+        title: "Test Conversation",
+        create_time: 1630454400,
+        update_time: 1630458000,
+        mapping: {
+          0: {
+            message: { author: { role: "assistant" }, content: { content_type: "reasoning_recap", content: "recap" } },
+          },
+        },
+      },
+    ];
+    await chatgptToMarkdown(json, tempDir);
+    const fileContent = await fs.readFile(path.join(tempDir, "Test Conversation.md"), "utf8");
+    expect(fileContent).toContain("> recap");
+  });
+
+  it("should handle sonic_webpage content", async () => {
+    const json = [
+      {
+        title: "Test Conversation",
+        create_time: 1630454400,
+        update_time: 1630458000,
+        mapping: {
+          0: {
+            message: {
+              author: { role: "tool", name: "web.search" },
+              content: { content_type: "sonic_webpage", url: "https://a.com", title: "Title", text: "Body" },
+            },
+          },
+        },
+      },
+    ];
+    await chatgptToMarkdown(json, tempDir);
+    const fileContent = await fs.readFile(path.join(tempDir, "Test Conversation.md"), "utf8");
+    expect(fileContent).toContain("Title (https://a.com)");
+    expect(fileContent).toContain("Body");
   });
 });


### PR DESCRIPTION
## Summary
- move message generation into a `nodeToMarkdown` helper
- append node info if an error occurs
- generate markdown for thoughts, reasoning recap and sonic webpage nodes
- test new content types
- show quotes and reasoning recaps as blockquotes

## Testing
- `npx -y prettier@3.5 --write --print-width=120 '**/*.js' '**/*.md'`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68526b67507c832cb113080097ec1d4d