### PR TITLE
feat: Handle duplicate sanitized titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx chatgpt-to-markdown path/to/your/conversations.json
 
 **NO NEED TO INSTALL** - `npx` will automatically install the package if it's not already installed.
 
-This will generate one Markdown file for each chat same directory as the conversations JSON file. The file name will be the chat title, with invalid filename characters replaced by spaces.
+This will generate one Markdown file for each chat same directory as the conversations JSON file. The file name will be the chat title, with invalid filename characters replaced by spaces. If multiple conversations have the same title, a suffix like ` (1)`, ` (2)` will be added to the filename.
 
 For example, the Markdown output for a chat with the title `Medium-Style Table CSS` might look like this:
 
@@ -109,6 +109,7 @@ git commit . -m"$COMMIT_MSG"; git tag $VERSION; git push --follow-tags
 
 ## Release notes
 
+- [1.8.1](https://npmjs.com/package/chatgpt-to-markdown/v/1.8.1): 2 Aug 2025. Handle duplicate titles by adding a suffix
 - [1.8.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.8.0): 30 Jul 2025. Standardized package.json & README.md
 - [1.7.1](https://npmjs.com/package/chatgpt-to-markdown/v/1.7.1): 29 Jun 2025. Add thinktime analysis tool as npx executable. Analyze thinking/reasoning time statistics from ChatGPT conversations
 - [1.6.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.6.0): 18 Jun 2025. Handle `thoughts`, `reasoning_recap`, `sonic_webpage`. Include projects

--- a/chatgpt-to-markdown.js
+++ b/chatgpt-to-markdown.js
@@ -136,9 +136,14 @@ async function chatgptToMarkdown(json, sourceDir, { dateFormat } = { dateFormat:
     throw new TypeError("The second argument must be a string.");
   }
 
+  const titleCounts = {};
   for (const conversation of json) {
     const sanitizedTitle = sanitizeFileName(conversation.title) || conversation.conversation_id;
-    const fileName = `${sanitizedTitle}.md`;
+    const count = titleCounts[sanitizedTitle] || 0;
+    titleCounts[sanitizedTitle] = count + 1;
+    const finalTitle = count > 0 ? `${sanitizedTitle} (${count})` : sanitizedTitle;
+
+    const fileName = `${finalTitle}.md`;
     const filePath = path.join(sourceDir, fileName);
     const title = `# ${wrapHtmlTagsInBackticks(conversation.title)}\n`;
     const lines = [

--- a/index.test.js
+++ b/index.test.js
@@ -455,4 +455,36 @@ describe("chatgptToMarkdown", () => {
     const fileContent = await fs.readFile(path.join(tempDir, "Test Conversation.md"), "utf8");
     expect(fileContent).toContain("- Project: https://chatgpt.com/g/g123/project");
   });
+
+  it("should handle duplicate titles by adding a suffix", async () => {
+    const json = [
+      {
+        title: "Duplicate Title",
+        create_time: 1630454400,
+        update_time: 1630458000,
+        conversation_id: "abc123",
+        mapping: {},
+      },
+      {
+        title: "Duplicate Title",
+        create_time: 1630454401,
+        update_time: 1630458001,
+        conversation_id: "def456",
+        mapping: {},
+      },
+      {
+        title: "Duplicate Title",
+        create_time: 1630454402,
+        update_time: 1630458002,
+        conversation_id: "ghi789",
+        mapping: {},
+      },
+    ];
+
+    await chatgptToMarkdown(json, tempDir);
+
+    await expect(fs.access(path.join(tempDir, "Duplicate Title.md"))).resolves.not.toThrow();
+    await expect(fs.access(path.join(tempDir, "Duplicate Title (1).md"))).resolves.not.toThrow();
+    await expect(fs.access(path.join(tempDir, "Duplicate Title (2).md"))).resolves.not.toThrow();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-to-markdown",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Convert ChatGPT exported conversations.json to Markdown",
   "homepage": "https://github.com/sanand0/chatgpt-to-markdown",
   "repository": {


### PR DESCRIPTION
Jules prompt:

> In case of a duplicate sanitizedTitle, rename it with a (1) suffix. If that exists, add (2) instead, and so on. For example, if there are 20 instances of the same sanitizedTitle "abc", the fileName values should be abc.md, abc (1).md, abc (2).md, ... abc (19).md.

> This checks if the filePath exists. We don't want to do that. We only want to check if sanitizedTitle is repeated across the conversations in the json. Also the change to chatgpt-to-markdown.js adds about a dozen lines. Keep it shorter.

> Update package.json to version 1.8.1. Update README.md.

In case of a duplicate sanitizedTitle, I will rename it with a (1) suffix. If that exists, I will add (2) instead, and so on. For example, if there are 20 instances of the same sanitizedTitle "abc", the fileName values should be `abc.md`, `abc (1).md`, `abc (2).md`, ... `abc (19).md`.