### PR TITLE
Handle duplicate titles with numeric suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npx chatgpt-to-markdown path/to/your/conversations.json
 **NO NEED TO INSTALL** - `npx` will automatically install the package if it's not already installed.
 
 This will generate one Markdown file for each chat same directory as the conversations JSON file. The file name will be the chat title, with invalid filename characters replaced by spaces.
+Duplicate titles get ` (1)`, ` (2)` suffixes to keep names unique.
 
 For example, the Markdown output for a chat with the title `Medium-Style Table CSS` might look like this:
 
@@ -109,6 +110,7 @@ git commit . -m"$COMMIT_MSG"; git tag $VERSION; git push --follow-tags
 
 ## Release notes
 
+- [1.9.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.9.0): 31 Jul 2025. Append numeric suffixes for duplicate chat titles
 - [1.8.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.8.0): 30 Jul 2025. Standardized package.json & README.md
 - [1.7.1](https://npmjs.com/package/chatgpt-to-markdown/v/1.7.1): 29 Jun 2025. Add thinktime analysis tool as npx executable. Analyze thinking/reasoning time statistics from ChatGPT conversations
 - [1.6.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.6.0): 18 Jun 2025. Handle `thoughts`, `reasoning_recap`, `sonic_webpage`. Include projects

--- a/chatgpt-to-markdown.js
+++ b/chatgpt-to-markdown.js
@@ -129,16 +129,15 @@ export const formatDate = (date) => dateFormat.format(date);
  * //=> Creates a markdown file for each conversation in the output directory
  */
 async function chatgptToMarkdown(json, sourceDir, { dateFormat } = { dateFormat: formatDate }) {
-  if (!Array.isArray(json)) {
-    throw new TypeError("The first argument must be an array.");
-  }
-  if (typeof sourceDir !== "string") {
-    throw new TypeError("The second argument must be a string.");
-  }
+  if (!Array.isArray(json)) throw new TypeError("The first argument must be an array.");
+  if (typeof sourceDir !== "string") throw new TypeError("The second argument must be a string.");
 
+  const counts = {};
   for (const conversation of json) {
     const sanitizedTitle = sanitizeFileName(conversation.title) || conversation.conversation_id;
-    const fileName = `${sanitizedTitle}.md`;
+    const count = counts[sanitizedTitle] || 0;
+    counts[sanitizedTitle] = count + 1;
+    const fileName = `${sanitizedTitle}${count ? ` (${count})` : ""}.md`;
     const filePath = path.join(sourceDir, fileName);
     const title = `# ${wrapHtmlTagsInBackticks(conversation.title)}\n`;
     const lines = [

--- a/index.test.js
+++ b/index.test.js
@@ -378,6 +378,25 @@ describe("chatgptToMarkdown", () => {
     await expect(fs.access(path.join(tempDir, "abc123.md"))).resolves.not.toThrow();
   });
 
+  it("should append numeric suffix for duplicate titles", async () => {
+    const json = [
+      { title: "Dup", conversation_id: "1", create_time: 1, update_time: 1, mapping: {} },
+      { title: "Dup", conversation_id: "2", create_time: 1, update_time: 1, mapping: {} },
+      { title: "Dup", conversation_id: "3", create_time: 1, update_time: 1, mapping: {} },
+    ];
+    await chatgptToMarkdown(json, tempDir);
+    await expect(fs.access(path.join(tempDir, "Dup.md"))).resolves.not.toThrow();
+    await expect(fs.access(path.join(tempDir, "Dup (1).md"))).resolves.not.toThrow();
+    await expect(fs.access(path.join(tempDir, "Dup (2).md"))).resolves.not.toThrow();
+  });
+
+  it("should ignore existing files when naming", async () => {
+    await fs.writeFile(path.join(tempDir, "Dup.md"), "old");
+    const json = [{ title: "Dup", conversation_id: "1", create_time: 1, update_time: 1, mapping: {} }];
+    await chatgptToMarkdown(json, tempDir);
+    await expect(fs.access(path.join(tempDir, "Dup (1).md"))).rejects.toThrow();
+  });
+
   it("should handle thoughts content", async () => {
     const json = [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-to-markdown",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-to-markdown",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "bin": {
         "chatgpt-to-markdown": "chatgpt-to-markdown-cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-to-markdown",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Convert ChatGPT exported conversations.json to Markdown",
   "homepage": "https://github.com/sanand0/chatgpt-to-markdown",
   "repository": {


### PR DESCRIPTION
Codex prompts

> In case of a duplicate sanitizedTitle, rename it with a (1) suffix. If that exists, add (2) instead, and so on. For example, if there are 20 instances of the same sanitizedTitle "abc", the fileName values should be `abc.md`, `abc (1).md`, `abc (2).md`, ... `abc (19).md`.

> This checks if the filePath exists. We don't want to do that. We only want to check if sanitizedTitle is repeated across the conversations in the json. Also the change to chatgpt-to-markdown.js adds about two dozen lines. Keep it MUCH shorter.

> Update package.json and package-lock.json and README.md to indicate this as version 1.9.0

## Summary
- ensure unique markdown filenames by appending numeric suffixes when chat titles repeat
- document duplicate title handling and bump package to v1.9.0
- cover unique filename generation with tests

## Testing
- `npx -y prettier@3.5 --write --print-width=120 '**/*.js' '**/*.md'`
- `npx -y prettier@3.5 --write package.json package-lock.json`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `npm test >/tmp/post-change-tests.log && tail -n 20 /tmp/post-change-tests.log`


------
https://chatgpt.com/codex/tasks/task_e_688e1d144bd4832ca47aa2d97efae66e