### PR TITLE
feat: Sort conversations by creation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ git commit . -m"$COMMIT_MSG"; git tag $VERSION; git push --follow-tags
 
 ## Release notes
 
+- [1.9.1](https://npmjs.com/package/chatgpt-to-markdown/v/1.9.1): 2 Aug 2025. Sort conversations by create_time to ensure chronological ordering of filenames
 - [1.9.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.9.0): 31 Jul 2025. Append numeric suffixes for duplicate chat titles
 - [1.8.0](https://npmjs.com/package/chatgpt-to-markdown/v/1.8.0): 30 Jul 2025. Standardized package.json & README.md
 - [1.7.1](https://npmjs.com/package/chatgpt-to-markdown/v/1.7.1): 29 Jun 2025. Add thinktime analysis tool as npx executable. Analyze thinking/reasoning time statistics from ChatGPT conversations

--- a/chatgpt-to-markdown.js
+++ b/chatgpt-to-markdown.js
@@ -132,6 +132,8 @@ async function chatgptToMarkdown(json, sourceDir, { dateFormat } = { dateFormat:
   if (!Array.isArray(json)) throw new TypeError("The first argument must be an array.");
   if (typeof sourceDir !== "string") throw new TypeError("The second argument must be a string.");
 
+  json.sort((a, b) => a.create_time - b.create_time);
+
   const counts = {};
   for (const conversation of json) {
     const sanitizedTitle = sanitizeFileName(conversation.title) || conversation.conversation_id;

--- a/index.test.js
+++ b/index.test.js
@@ -380,14 +380,24 @@ describe("chatgptToMarkdown", () => {
 
   it("should append numeric suffix for duplicate titles", async () => {
     const json = [
-      { title: "Dup", conversation_id: "1", create_time: 1, update_time: 1, mapping: {} },
-      { title: "Dup", conversation_id: "2", create_time: 1, update_time: 1, mapping: {} },
-      { title: "Dup", conversation_id: "3", create_time: 1, update_time: 1, mapping: {} },
+      // Note the create_time values are not in order
+      { title: "Dup", conversation_id: "2", create_time: 1630454402, update_time: 1, mapping: {} },
+      { title: "Dup", conversation_id: "3", create_time: 1630454403, update_time: 1, mapping: {} },
+      { title: "Dup", conversation_id: "1", create_time: 1630454401, update_time: 1, mapping: {} },
     ];
     await chatgptToMarkdown(json, tempDir);
     await expect(fs.access(path.join(tempDir, "Dup.md"))).resolves.not.toThrow();
     await expect(fs.access(path.join(tempDir, "Dup (1).md"))).resolves.not.toThrow();
     await expect(fs.access(path.join(tempDir, "Dup (2).md"))).resolves.not.toThrow();
+
+    const firstFileContent = await fs.readFile(path.join(tempDir, "Dup.md"), "utf8");
+    expect(firstFileContent).toContain("https://chatgpt.com/c/1");
+
+    const secondFileContent = await fs.readFile(path.join(tempDir, "Dup (1).md"), "utf8");
+    expect(secondFileContent).toContain("https://chatgpt.com/c/2");
+
+    const thirdFileContent = await fs.readFile(path.join(tempDir, "Dup (2).md"), "utf8");
+    expect(thirdFileContent).toContain("https://chatgpt.com/c/3");
   });
 
   it("should ignore existing files when naming", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-to-markdown",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-to-markdown",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "bin": {
         "chatgpt-to-markdown": "chatgpt-to-markdown-cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-to-markdown",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Convert ChatGPT exported conversations.json to Markdown",
   "homepage": "https://github.com/sanand0/chatgpt-to-markdown",
   "repository": {


### PR DESCRIPTION
Jules prompts:

> Sort the json by .create_time before creating the files. This ensures that the filename counts will be in chronological order. Modify the test case so that the create_time is different and not sorted. Test that the correct conversations as saved as Dup.md, Dup (1).md and Dup (2).md by making sure the create_time matches (to within a reasonable precision).

> Update package.json, package-lock.json and README.md to nudge the version up to 1.9.1.

Sort the json by .create_time before creating the files. This ensures that the filename counts will be in chronological order.

The test case for duplicate filenames has been updated to:
- Use different and unsorted `create_time` values.
- Verify that the correct conversations are saved as Dup.md, Dup (1).md, and Dup (2).md by checking their content for the correct conversation ID.